### PR TITLE
undeleted ethereum in simulated.go

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 	"time"
 
-	ethereum "github.com/wanchain/go-wanchain"
 	"github.com/wanchain/go-wanchain/accounts/abi/bind"
 	"github.com/wanchain/go-wanchain/common"
 	"github.com/wanchain/go-wanchain/common/math"

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/wanchain/go-wanchain"
 	"github.com/wanchain/go-wanchain/accounts/abi/bind"
 	"github.com/wanchain/go-wanchain/common"
 	"github.com/wanchain/go-wanchain/common/math"


### PR DESCRIPTION
In the accounts/abi/bind/backends/simulated.go file
Line 27: ethereum "github.com/wanachain/go-wanchain"

Guess it wasn't deleted from Ethereum's original source code.